### PR TITLE
Changed TestableAggregateRoot to be explicit on commandhandling failures

### DIFF
--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/SpecConfig.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/SpecConfig.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016-2018 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.test
+
+import com.typesafe.config.ConfigFactory
+
+object SpecConfig {
+
+  /*
+  PLEASE NOTE:
+  Currently the https://github.com/dnvriend/akka-persistence-inmemory is NOT working for Aggregate Root tests
+  because it is not possible to use a separate instance writing the events that should be in the event store
+  before you actually create the aggregate root (should replay those stored events) to check execution of a new
+  command.
+  A new configuration that uses the akka bundled inmem storage is added to create a working situation.
+   */
+  val testConfig = ConfigFactory.parseString(
+    """
+      |      akka {
+      |        loglevel = "DEBUG"
+      |        stdout-loglevel = "DEBUG"
+      |        loggers = ["akka.testkit.TestEventListener"]
+      |        actor {
+      |          default-dispatcher {
+      |            executor = "fork-join-executor"
+      |            fork-join-executor {
+      |              parallelism-min = 8
+      |              parallelism-factor = 2.0
+      |              parallelism-max = 8
+      |            }
+      |          }
+      |          serialize-creators = off
+      |          serialize-messages = off
+      |        }
+      |      persistence {
+      |       publish-confirmations = on
+      |       publish-plugin-commands = on
+      |       journal {
+      |          plugin = "inmemory-journal"
+      |       }
+      |       snapshot-store.plugin = "inmemory-snapshot-store"
+      |      }
+      |      test {
+      |        single-expect-default = 10s
+      |        timefactor = 1
+      |      }
+      |    }
+      |    inmemory-read-journal {
+      |      refresh-interval = "10ms"
+      |      max-buffer-size = "1000"
+      |    }
+      |
+      |    bounded.eventmaterializers.publish = true
+      |
+      |    bounded.eventmaterializers.offsetstore {
+      |       type = "inmemory"
+      |   }
+    """.stripMargin
+  )
+
+}

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestAggregateRoot.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestAggregateRoot.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2018 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.test
+
+import akka.actor.{ActorSystem, Props}
+import io.cafienne.bounded.{BuildInfo, RuntimeInfo}
+import io.cafienne.bounded.aggregate._
+import io.cafienne.bounded.test.TestAggregateRoot.TestAggregateRootState
+import scala.collection.immutable.Seq
+
+//object DomainProtocol {
+case class TestAggregateRootId(id: String) extends AggregateRootId {
+  override def idAsString: String = id
+}
+
+case class CreateInitialState(metaData: CommandMetaData, aggregateRootId: AggregateRootId, state: String)
+    extends DomainCommand
+case class InitialStateCreated(metaData: MetaData, id: AggregateRootId, state: String) extends DomainEvent
+
+case class UpdateState(metaData: CommandMetaData, aggregateRootId: AggregateRootId, state: String) extends DomainCommand
+case class StateUpdated(metaData: MetaData, id: AggregateRootId, state: String)                    extends DomainEvent
+
+case class InvalidCommand(msg: String) extends HandlingFailure
+case class InvalidState(msg: String)   extends HandlingFailure
+//}
+
+class TestAggregateRoot(aggregateRootId: AggregateRootId, buildInfo: BuildInfo, runtimeInfo: RuntimeInfo)
+    extends AggregateRootActor[TestAggregateRootState] {
+  //import DomainProtocol._
+
+  implicit val bi = buildInfo
+  implicit val ri = runtimeInfo
+
+  override def aggregateId: AggregateRootId = aggregateRootId
+
+  override def handleCommand(command: DomainCommand, aggregateState: Option[TestAggregateRootState]): Reply = {
+    command match {
+      case CreateInitialState(metaData, aggregateRootId, state) =>
+        Ok(Seq[DomainEvent](InitialStateCreated(MetaData.fromCommand(metaData), aggregateRootId, state)))
+      case UpdateState(metaData, aggregateRootId, state) =>
+        if (aggregateState.isDefined && aggregateState.get.state.equals("new")) {
+          Ok(Seq(StateUpdated(MetaData.fromCommand(metaData), aggregateRootId, state)))
+        } else {
+          Ko(InvalidState(s"The current state $aggregateState does not allow an update to $state"))
+        }
+      case other => Ko(new UnexpectedCommand(other))
+    }
+  }
+
+  override def newState(evt: DomainEvent): Option[TestAggregateRootState] = {
+    evt match {
+      case InitialStateCreated(metaData, id, state) => Some(TestAggregateRootState(state))
+      case _ =>
+        log.error("Event {} is not valid to create a new TestAggregateRootState")
+        throw new IllegalArgumentException(s"Event $evt is not valid to create a new TestAggregateRootState")
+    }
+  }
+}
+
+object TestAggregateRoot {
+
+  case class TestAggregateRootState(state: String) extends AggregateState[TestAggregateRootState] {
+    override def update(event: DomainEvent): Option[TestAggregateRootState] = {
+      event match {
+        case evt: StateUpdated =>
+          Some(this.copy(state = evt.state))
+        case other => throw new IllegalArgumentException(s"Cannot update state based on event $other")
+      }
+    }
+  }
+
+  val aggregateRootTag = "ar-test"
+}
+
+class TestAggregateRootCreator(system: ActorSystem)(implicit buildInfo: BuildInfo, runtimeInfo: RuntimeInfo)
+    extends AggregateRootCreator {
+
+  override def props(aggregateRootId: AggregateRootId): Props = {
+    system.log.debug("Returning new Props for {}", aggregateRootId)
+    Props(classOf[TestAggregateRoot], aggregateRootId, buildInfo, runtimeInfo)
+  }
+
+}

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2016-2018 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.test
+
+import java.time.ZonedDateTime
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.testkit.TestKit
+import akka.util.Timeout
+import io.cafienne.bounded.{BuildInfo, RuntimeInfo}
+import io.cafienne.bounded.aggregate.{AggregateRootId, CommandMetaData, MetaData}
+import io.cafienne.bounded.test.TestableAggregateRoot.{CommandHandlingException, IllegalCommandException}
+//import io.cafienne.bounded.test.DomainProtocol.InitialStateCreated
+import io.cafienne.bounded.test.TestAggregateRoot.TestAggregateRootState
+import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.duration._
+
+class TestableAggregateRootSpec extends AsyncWordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  //Setup required supporting classes
+  implicit val timeout                = Timeout(10.seconds)
+  implicit val system                 = ActorSystem("TestSystem", SpecConfig.testConfig)
+  implicit val logger: LoggingAdapter = Logging(system, getClass)
+  implicit val buildInfo              = BuildInfo("spec", "1.0")
+  implicit val runtimeInfo            = RuntimeInfo("current")
+
+  val testAggregateRootCreator = new TestAggregateRootCreator(system)
+
+  val currentMeta = MetaData(ZonedDateTime.parse("2018-01-01T17:43:00+01:00"), None, None, buildInfo, runtimeInfo)
+
+  "The testable aggregate root" must {
+
+    "create without state in given" in {
+      val testAggregateRootId1 = TestAggregateRootId("1")
+
+      val targetState = TestAggregateRootState("new")
+
+      val ar = TestableAggregateRoot
+        .given[TestAggregateRoot, TestAggregateRootState](testAggregateRootCreator, testAggregateRootId1)
+
+      ar.currentState map { state =>
+        assert(state.isEmpty)
+      }
+    }
+
+    "create initial state in given" in {
+      val testAggregateRootId1 = TestAggregateRootId("2")
+      val targetState          = TestAggregateRootState("new")
+
+      val ar = TestableAggregateRoot
+        .given[TestAggregateRoot, TestAggregateRootState](
+          testAggregateRootCreator,
+          testAggregateRootId1,
+          InitialStateCreated(currentMeta, testAggregateRootId1, "new")
+        )
+
+      ar.currentState map { state =>
+        assert(state.isDefined, s"There is no defined state but expected $targetState")
+        assert(state.get == targetState)
+      }
+    }
+
+    "handle the command to OK in when" in {
+      val testAggregateRootId1 = TestAggregateRootId("3")
+      val commandMetaData      = CommandMetaData(currentMeta.timestamp, None)
+      val updateStateCommand   = UpdateState(commandMetaData, testAggregateRootId1, "updated")
+      val targetState          = TestAggregateRootState("updated")
+
+      val ar = TestableAggregateRoot
+        .given[TestAggregateRoot, TestAggregateRootState](
+          testAggregateRootCreator,
+          testAggregateRootId1,
+          InitialStateCreated(currentMeta, testAggregateRootId1, "new")
+        )
+        .when(updateStateCommand)
+
+      ar.events should contain(StateUpdated(MetaData.fromCommand(commandMetaData), testAggregateRootId1, "updated"))
+
+      ar.currentState map { state =>
+        assert(state.isDefined, s"There is no defined state but expected $targetState")
+        assert(state.get == targetState)
+      }
+    }
+
+    "handle the CommandHandlingException to KO in when" in {
+      val testAggregateRootId1 = TestAggregateRootId("3")
+      val commandMetaData      = CommandMetaData(currentMeta.timestamp, None)
+      val updateStateCommand   = UpdateState(commandMetaData, testAggregateRootId1, "updated")
+
+      an[CommandHandlingException] should be thrownBy {
+        val ar = TestableAggregateRoot
+          .given[TestAggregateRoot, TestAggregateRootState](
+            testAggregateRootCreator,
+            testAggregateRootId1,
+            InitialStateCreated(currentMeta, testAggregateRootId1, "wronginitial")
+          )
+          .when(updateStateCommand)
+      }
+    }
+
+    "handle the IllegalCommandException to KO in when" in {
+      val testAggregateRootId1               = TestAggregateRootId("4")
+      val testAggregateRootIdWrongForCommand = TestAggregateRootId("5")
+      val commandMetaData                    = CommandMetaData(currentMeta.timestamp, None)
+      val updateStateCommand                 = UpdateState(commandMetaData, testAggregateRootIdWrongForCommand, "updated")
+
+      an[IllegalCommandException] should be thrownBy {
+        val ar = TestableAggregateRoot
+          .given[TestAggregateRoot, TestAggregateRootState](
+            testAggregateRootCreator,
+            testAggregateRootId1,
+            InitialStateCreated(currentMeta, testAggregateRootId1, "new")
+          )
+          .when(updateStateCommand)
+      }
+    }
+
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, 30.seconds, verifySystemShutdown = true)
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 lazy val basicSettings = {
-  val currentScalaVersion = "2.12.3"
-  val scala211Version     = "2.11.11"
+  val currentScalaVersion = "2.12.6"
+  val scala211Version     = "2.11.12"
 
   Seq(
     organization := "io.cafienne.bounded",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
Ensured TestableAggregateRoot works properly based on a starting 'given' (the actor was created in when, that is now part of given that is actually class constructor work)
Added tests to cover the functionality of TestableAggregateRoot