### PR TITLE
Remove dependency of events of type DomainEvent in materializers.

### DIFF
--- a/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractEventMaterializer.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractEventMaterializer.scala
@@ -15,8 +15,6 @@ import io.cafienne.bounded.akka.ActorSystemProvider
 import io.cafienne.bounded.akka.persistence.ReadJournalProvider
 import io.cafienne.bounded.config.Configured
 import com.typesafe.scalalogging.Logger
-import io.cafienne.bounded.aggregate.DomainEvent
-import io.cafienne.bounded._
 import io.cafienne.bounded.eventmaterializers.offsetstores.OffsetStore
 
 import scala.concurrent.{Await, Future}
@@ -83,9 +81,9 @@ abstract class AbstractEventMaterializer(
   /**
     * Publish an event on the AKKA eventbus after the event is processed.
     */
-  val isPublishRequired: Boolean = (actorSystem.settings.config
+  val isPublishRequired: Boolean = actorSystem.settings.config
     .hasPath("bounded.eventmaterializers.publish") && actorSystem.settings.config
-    .getBoolean("bounded.eventmaterializers.publish"))
+    .getBoolean("bounded.eventmaterializers.publish")
 
   /**
     * Register listener for events. Should be registered *after* replay is finished
@@ -103,7 +101,7 @@ abstract class AbstractEventMaterializer(
     val source: Source[EventEnvelope, NotUsed] =
       journal
         .eventsByTag(tagName, listenStartOffset)
-        .filter(eventEnvelope => materialzerEventFilter.filter(eventEnvelope.event.asInstanceOf[DomainEvent]))
+        .filter(eventEnvelope => materialzerEventFilter.filter(eventEnvelope.event))
     val lastSnk = Sink.last[Offset]
     val answer = source
       .mapAsync(1) {

--- a/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractReplayableEventMaterializer.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractReplayableEventMaterializer.scala
@@ -8,7 +8,6 @@ import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.persistence.query.{EventEnvelope, Offset}
 import akka.stream.scaladsl.Source
-import io.cafienne.bounded.aggregate.DomainEvent
 
 import scala.concurrent.Future
 
@@ -50,7 +49,7 @@ abstract class AbstractReplayableEventMaterializer(
     val source: Source[EventEnvelope, NotUsed] =
       journal
         .currentEventsByTag(tagName, targetOffset)
-        .filter(eventEnvelope => materializerEventFilter.filter(eventEnvelope.event.asInstanceOf[DomainEvent]))
+        .filter(eventEnvelope => materializerEventFilter.filter(eventEnvelope.event))
     source
       .runFoldAsync(targetOffset) {
         case (previousOffset, EventEnvelope(offset, persistenceId, sequenceNo, evt)) =>

--- a/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/MaterializerEventFilter.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/MaterializerEventFilter.scala
@@ -17,7 +17,7 @@ trait MaterializerEventFilter {
     * @param evt DomainEvent that is to be evaluated
     * @return true when the event needs to be processed, false when it needs to be skipped
     */
-  def filter(evt: DomainEvent): Boolean
+  def filter(evt: Any): Boolean
 
 }
 
@@ -43,12 +43,14 @@ class RuntimeMaterializerEventFilter(
   compatible: Compatibility = DefaultCompatibility
 ) extends MaterializerEventFilter {
 
-  override def filter(evt: DomainEvent): Boolean = {
-    compatible match {
-      case Compatibility(RuntimeCompatibility.ALL) => true
-      case Compatibility(RuntimeCompatibility.CURRENT) =>
-        evt.metaData.runTimeInfo.id.equals(runtimeInfo.id)
-    }
+  override def filter(evt: Any): Boolean = evt match {
+    case e: DomainEvent =>
+      compatible match {
+        case Compatibility(RuntimeCompatibility.ALL) => true
+        case Compatibility(RuntimeCompatibility.CURRENT) =>
+          e.metaData.runTimeInfo.id.equals(runtimeInfo.id)
+      }
+    case _ => true // Unknown events are passed
   }
 }
 
@@ -56,5 +58,5 @@ class RuntimeMaterializerEventFilter(
   * A Default Filter that will accept all events to be processed. This is used as default behaviour of the Event Materializers.
   */
 object NoFilterEventFilter extends MaterializerEventFilter {
-  override def filter(evt: DomainEvent): Boolean = true
+  override def filter(evt: Any): Boolean = true
 }


### PR DESCRIPTION
I want to use the materializers in an environment (cafienne) with custom (not inherited from DomainEvent) events. This change makes the filter approach more generic and removes the dependency to DomainEvents.