### PR TITLE
Removed extends on DefaultJsonProtocol

### DIFF
--- a/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/ProtocolJsonProtocol.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/ProtocolJsonProtocol.scala
@@ -13,7 +13,9 @@ import io.cafienne.bounded._
 import io.cafienne.bounded.eventmaterializers.{Compatibility, RuntimeCompatibility}
 import spray.json._
 
-object ProtocolJsonProtocol extends DefaultJsonProtocol {
+object ProtocolJsonProtocol {
+
+  import spray.json.DefaultJsonProtocol._
 
   implicit val BuildInfoJsonFormat            = jsonFormat2(BuildInfo)
   implicit val RuntimeInfoJsonFormat          = jsonFormat1(RuntimeInfo)

--- a/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractEventMaterializer.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/eventmaterializers/AbstractEventMaterializer.scala
@@ -16,7 +16,6 @@ import io.cafienne.bounded.akka.persistence.ReadJournalProvider
 import io.cafienne.bounded.config.Configured
 import com.typesafe.scalalogging.Logger
 import io.cafienne.bounded.aggregate.DomainEvent
-import io.cafienne.bounded._
 import io.cafienne.bounded.eventmaterializers.offsetstores.OffsetStore
 
 import scala.concurrent.{Await, Future}


### PR DESCRIPTION
The extends on DefaultJsonProtocol in ProtocolJsonProtocol results in errors when importing the complete object:
`import io.cafienne.bounded.aggregate.ProtocolJsonProtocol`

This can result in errors like this one:
```
Error:(19, 43) reference to jsonFormat2 is ambiguous;
it is imported twice in the same scope by
import io.cafienne.bounded.aggregate.ProtocolJsonProtocol._
and import spray.json.DefaultJsonProtocol._
```