### PR TITLE
Typed support2

### DIFF
--- a/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/Protocol.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/Protocol.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.aggregate
 
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 import akka.actor.typed.ActorRef
@@ -20,7 +20,7 @@ import stamina.Persistable
   * @param userContext contains an assumed known user, events generated via an HTTP API will most of the time be authenticated
   */
 trait CommandMetaData {
-  def timestamp: ZonedDateTime
+  def timestamp: OffsetDateTime
   def userContext: Option[UserContext]
   def commandId: UUID = UUID.randomUUID()
 }
@@ -45,7 +45,7 @@ trait ReplyTo {
   * @param runTimeInfo contains information on the runtime the event is generated and stored
   */
 trait MetaData {
-  def timestamp: ZonedDateTime
+  def timestamp: OffsetDateTime
   def userContext: Option[UserContext]
   def causedByCommand: Option[UUID]
   def buildInfo: BuildInfo

--- a/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/ProtocolJsonProtocol.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/ProtocolJsonProtocol.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.aggregate
 
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -33,18 +33,17 @@ object ProtocolJsonProtocol {
       }
     }
 
-  implicit object ZonedDateTimeJsonFormat extends RootJsonFormat[ZonedDateTime] {
+  implicit object OffsetDateTimeJsonFormat extends RootJsonFormat[OffsetDateTime] {
 
-    def write(dt: ZonedDateTime): JsValue =
+    def write(dt: OffsetDateTime): JsValue =
       JsString(
         dt.truncatedTo(ChronoUnit.SECONDS)
-          .toOffsetDateTime
           .format(DateTimeFormatter.ISO_DATE_TIME)
       )
 
-    def read(value: JsValue): ZonedDateTime = value match {
+    def read(value: JsValue): OffsetDateTime = value match {
       case JsString(v) =>
-        ZonedDateTime.parse(v, DateTimeFormatter.ISO_DATE_TIME)
+        OffsetDateTime.parse(v, DateTimeFormatter.ISO_DATE_TIME)
       case _ =>
         deserializationError(s"value $value not conform ISO8601 (yyyy-MM-dd'T'HH:mm:ssZZ) where time is optional")
     }

--- a/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedClusteredSpec.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedClusteredSpec.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.aggregate
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 
 import akka.actor.testkit.typed.scaladsl.{ActorTestKit, ScalaTestWithActorTestKit}
 import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, Entity}
@@ -38,17 +38,17 @@ class TypedClusteredSpec extends ScalaTestWithActorTestKit(s"""
 
   behavior of "Typed Cluster"
 
-  val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+  val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
 
   val creator = new SimpleAggregateManager()
-//  val sharding = ClusterSharding(system)
+//  val sharding = ClusterSharding(system)test
 //
 //  sharding.init(
 //    Entity(creator.entityTypeKey)(createBehavior = entityContext => creator.behavior(entityContext.entityId))
 //  )
 
   "ShardedCluster" should "Create a basic non-clustered aggregate and send command" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
 
     val aggregateId = "test0"
     val creator     = new SimpleAggregateManager()

--- a/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedCommandGatewaySpec.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedCommandGatewaySpec.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.aggregate
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 
 import akka.actor.testkit.typed.javadsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.{LogCapturing, ManualTime, ScalaTestWithActorTestKit}
@@ -51,12 +51,12 @@ class TypedCommandGatewaySpec extends ScalaTestWithActorTestKit(s"""
   implicit val buildInfo      = BuildInfo("spec", "1.0")
   implicit val runtimeInfo    = RuntimeInfo("current")
 
-  val commandMetaData     = AggregateCommandMetaData(ZonedDateTime.now(), None)
+  val commandMetaData     = AggregateCommandMetaData(OffsetDateTime.now(), None)
   val creator             = new SimpleAggregateManager()
   val typedCommandGateway = new DefaultTypedCommandGateway[SimpleAggregateCommand](system, creator)
 
   "Command Gateway" should "send Create command" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
     val aggregateId     = "test0"
     val probe           = testKit.createTestProbe[Response]()
     whenReady(typedCommandGateway.tell(Create(aggregateId, commandMetaData, probe.ref))) { answer =>
@@ -68,7 +68,7 @@ class TypedCommandGatewaySpec extends ScalaTestWithActorTestKit(s"""
   }
 
   "Command Gateway" should "work with send and ask" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
     val aggregateId     = "testask"
     whenReady(typedCommandGateway.ask(aggregateId, ref => Create(aggregateId, commandMetaData, ref))) {
       answer: Response => answer shouldEqual (OK)
@@ -76,7 +76,7 @@ class TypedCommandGatewaySpec extends ScalaTestWithActorTestKit(s"""
   }
 
   "Command Gateway" should "handle second message via actor in the Map" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
     val aggregateId     = "test0"
     val probe           = testKit.createTestProbe[Response]()
     whenReady(typedCommandGateway.tell(AddItem(aggregateId, commandMetaData, "new item 1", probe.ref))) { answer =>
@@ -87,7 +87,7 @@ class TypedCommandGatewaySpec extends ScalaTestWithActorTestKit(s"""
   }
 
   "Command Gateway" should "recover after stop message and add to the map" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
     val aggregateId     = "test0"
     val probe           = testKit.createTestProbe[Response]()
     whenReady(typedCommandGateway.tell(Stop(aggregateId, commandMetaData, probe.ref))) { answer =>
@@ -103,7 +103,7 @@ class TypedCommandGatewaySpec extends ScalaTestWithActorTestKit(s"""
   }
 
   "Command Gateway" should "recover after the aggregate stopped itself" in {
-    val commandMetaData = AggregateCommandMetaData(ZonedDateTime.now(), None)
+    val commandMetaData = AggregateCommandMetaData(OffsetDateTime.now(), None)
     val aggregateId     = "test0"
     val probe           = testKit.createTestProbe[Response]()
     whenReady(typedCommandGateway.tell(StopAfter(aggregateId, commandMetaData, 3, probe.ref))) { answer =>

--- a/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedSimpleAggregate.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/TypedSimpleAggregate.scala
@@ -11,8 +11,9 @@ import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior, ReplyEffec
 import com.typesafe.scalalogging.Logger
 import io.cafienne.bounded.{BuildInfo, RuntimeInfo, UserContext}
 import io.cafienne.bounded.aggregate.typed.TypedAggregateRootManager
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 import java.util.UUID
+
 import scala.concurrent.duration._
 import akka.actor.typed.scaladsl.{Behaviors, TimerScheduler}
 import akka.persistence.RecoveryCompleted
@@ -33,7 +34,7 @@ object TypedSimpleAggregate {
   final case class Items(items: List[String]) extends Response
 
   // Command Type
-  final case class AggregateCommandMetaData(timestamp: ZonedDateTime, userContext: Option[UserContext])
+  final case class AggregateCommandMetaData(timestamp: OffsetDateTime, userContext: Option[UserContext])
       extends CommandMetaData
 
   sealed trait SimpleAggregateCommand extends DomainCommand
@@ -171,7 +172,7 @@ class SimpleAggregateManager() extends TypedAggregateRootManager[SimpleAggregate
 }
 
 case class TestMetaData(
-  timestamp: ZonedDateTime,
+  timestamp: OffsetDateTime,
   userContext: Option[UserContext],
   causedByCommand: Option[UUID],
   buildInfo: BuildInfo,

--- a/bounded-core/src/test/scala/io/cafienne/bounded/eventmaterializers/AbstractReplayableEventMaterializerWithRuntimeEventFilterSpec.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/eventmaterializers/AbstractReplayableEventMaterializerWithRuntimeEventFilterSpec.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.eventmaterializers
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 import java.util.UUID
 
 import akka.Done
@@ -27,7 +27,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 case class TestMetaData(
-  timestamp: ZonedDateTime,
+  timestamp: OffsetDateTime,
   userContext: Option[UserContext],
   causedByCommand: Option[UUID],
   buildInfo: BuildInfo,
@@ -62,7 +62,7 @@ class AbstractReplayableEventMaterializerWithRuntimeEventFilterSpec
   val futureBuild   = buildInfo.copy(version = "1.1")
 
   val currentMeta =
-    TestMetaData(ZonedDateTime.parse("2018-01-01T17:43:00+01:00"), None, None, currentBuild, currentRuntime)
+    TestMetaData(OffsetDateTime.parse("2018-01-01T17:43:00+01:00"), None, None, currentBuild, currentRuntime)
 
   val testSet = Seq(
     TestedEvent(currentMeta, "current-current"),

--- a/bounded-test/src/main/scala/io/cafienne/bounded/test/CreateEventsInStoreActor.scala
+++ b/bounded-test/src/main/scala/io/cafienne/bounded/test/CreateEventsInStoreActor.scala
@@ -5,23 +5,33 @@
 package io.cafienne.bounded.test
 
 import akka.actor.{ActorContext, ActorRef}
-import akka.persistence.PersistentActor
+import akka.persistence.{PersistentActor, RecoveryCompleted}
+import akka.persistence.journal.Tagged
 import akka.persistence.typed.PersistenceId
 import io.cafienne.bounded.aggregate.DomainEvent
 
-class CreateEventsInStoreActor(aggregateId: String) extends PersistentActor {
+class CreateEventsInStoreActor(aggregateId: String, tags: Set[String] = Set.empty) extends PersistentActor {
   override def persistenceId: String = aggregateId
 
   override def receiveRecover: Receive = {
+    case RecoveryCompleted => // thats fine.
     case other =>
       context.system.log.debug("received unknown event to recover:" + other)
   }
 
   override def receiveCommand: Receive = {
     case evt: DomainEvent => {
-      persist(evt) { e =>
-        context.system.log.debug(s"persisted $e")
-        sender() ! e
+      if (tags.isEmpty) {
+        persist(evt) { e =>
+          context.system.log.debug(s"persisted $e")
+          sender() ! e
+        }
+      } else {
+        persist(Tagged(evt, tags)) { e =>
+          context.system.log.debug(s"persisted $e")
+          val Tagged(event, _) = e
+          sender() ! event
+        }
       }
     }
     case other => context.system.log.error(s"cannot handle command $other")

--- a/bounded-test/src/main/scala/io/cafienne/bounded/test/TestableAggregateRoot.scala
+++ b/bounded-test/src/main/scala/io/cafienne/bounded/test/TestableAggregateRoot.scala
@@ -111,7 +111,7 @@ class TestableAggregateRoot[A <: AggregateRootActor[B], B <: AggregateState[B]: 
 
   private def storeEvents(evt: Seq[DomainEvent]): Unit = {
     val storeEventsActor = system.actorOf(
-      Props(classOf[CreateEventsInStoreActor], arTestId),
+      Props(classOf[CreateEventsInStoreActor], arTestId, Set.empty),
       "create-events-actor"
     )
     val testProbe = TestProbe()

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestMetaData.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestMetaData.scala
@@ -4,20 +4,20 @@
 
 package io.cafienne.bounded.test
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 import java.util.UUID
 
 import io.cafienne.bounded.aggregate.{CommandMetaData, MetaData}
 import io.cafienne.bounded.{BuildInfo, RuntimeInfo, UserContext}
 
 case class TestCommandMetaData(
-  timestamp: ZonedDateTime,
+  timestamp: OffsetDateTime,
   val userContext: Option[UserContext],
   override val commandId: UUID = UUID.randomUUID()
 ) extends CommandMetaData
 
 case class TestMetaData(
-  timestamp: ZonedDateTime,
+  timestamp: OffsetDateTime,
   userContext: Option[UserContext],
   causedByCommand: Option[UUID],
   buildInfo: BuildInfo,

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
@@ -4,7 +4,7 @@
 
 package io.cafienne.bounded.test
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZonedDateTime}
 
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
@@ -33,7 +33,7 @@ class TestableAggregateRootSpec extends AsyncWordSpecLike with Matchers with Sca
 
   val testAggregateRootCreator = new TestAggregateRootCreator(system)
 
-  val currentMeta = TestMetaData(ZonedDateTime.parse("2018-01-01T17:43:00+01:00"), None, None, buildInfo, runtimeInfo)
+  val currentMeta = TestMetaData(OffsetDateTime.parse("2018-01-01T17:43:00+01:00"), None, None, buildInfo, runtimeInfo)
   val metaData    = TestCommandMetaData(currentMeta.timestamp, None)
 
   "The testable aggregate root" must {

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.2.1-SNAPSHOT"


### PR DESCRIPTION
Allows for using tags directly when events are stored (without the configured event adapter)
Changed the use of ZonedDateTime to OffsetDateTime. 