### PR TITLE
Aggregate Idle passivation

### DIFF
--- a/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/CommandGateway.scala
+++ b/bounded-core/src/main/scala/io/cafienne/bounded/aggregate/CommandGateway.scala
@@ -4,10 +4,12 @@
 
 package io.cafienne.bounded.aggregate
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{Actor, ActorContext, ActorRef, ActorSystem, Props, Terminated, TimerScheduler, Timers}
 import akka.event.{Logging, LoggingAdapter}
+import akka.routing.{NoRoutee, Routee, RoutingLogic}
 import akka.util.Timeout
-
+import scala.collection.immutable
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 trait CommandGateway {
@@ -36,15 +38,115 @@ class DefaultCommandGateway[A <: AggregateRootCreator](system: ActorSystem, aggr
   }
 
   override def sendAndAsk[T <: DomainCommand](command: T)(implicit validator: ValidateableCommand[T]): Future[_] = {
+//    getAggregateRoot(command).ask(command)
     CommandValidator
       .validate(command)
-      .flatMap(validatedCommand => getAggregateRoot(command) ? validatedCommand)
+      .flatMap(validatedCommand => {
+        val foundAr = getAggregateRoot(command)
+        logger.debug("sendAndAsk cmd {} to {} ", validatedCommand.getClass.getSimpleName, foundAr)
+        foundAr ? validatedCommand
+      })
   }
 
   override def send[T <: DomainCommand](command: T)(implicit validator: ValidateableCommand[T]): Future[Unit] = {
     CommandValidator
       .validate(command)
-      .map(validatedCommand => getAggregateRoot(command) ! validatedCommand)
+      .map(validatedCommand => {
+        val foundAr = getAggregateRoot(command)
+        logger.debug("send cmd {} to {} ", validatedCommand.getClass.getSimpleName, foundAr)
+        foundAr ! validatedCommand
+      })
   }
 
+}
+
+class RouterCommandGateway[A <: AggregateRootCreator](
+  system: ActorSystem,
+  idleTime: FiniteDuration,
+  aggregateRootCreator: A
+)(
+  implicit timeout: Timeout,
+  ec: ExecutionContext
+) extends CommandGateway {
+  import akka.pattern.ask
+
+  implicit val actorSystem: ActorSystem = system
+  val logger: LoggingAdapter            = Logging(system, getClass)
+
+  val gatewayActor = actorSystem.actorOf(Props(new AggregateGatewayRouter(aggregateRootCreator, idleTime)))
+
+  override def sendAndAsk[T <: DomainCommand](command: T)(implicit validator: ValidateableCommand[T]): Future[_] = {
+    for {
+      validatedCommand <- CommandValidator.validate(command)
+      answer           <- gatewayActor ? validatedCommand
+    } yield answer
+  }
+
+  override def send[T <: DomainCommand](command: T)(implicit validator: ValidateableCommand[T]): Future[Unit] = {
+    CommandValidator
+      .validate(command)
+      .map(validatedCommand => gatewayActor ! validatedCommand)
+  }
+
+}
+
+import akka.routing.{ActorRefRoutee, Router}
+
+private class AggregateGatewayRouter[A <: AggregateRootCreator](aggregateRootCreator: A, idleTime: FiniteDuration)
+    extends Actor
+    with Timers {
+  import AggregateRoutingLogic._
+  val routeeMap = collection.mutable.Map[String, ActorRef]()
+
+  val aggregateRouter = new AggregateRoutingLogic(routeeMap)
+  var router          = Router(aggregateRouter, Vector.empty)
+
+  def receive: Receive = {
+    case w: DomainCommand =>
+      context.system.log.debug("Route message {}", w)
+      //Aggregate is created when it does not exist, required to ensure that it will be in the map used
+      //in the routing logic.
+      ensureAggregateIsRunning(w.aggregateRootId)
+      router.route(w, sender())
+    case Terminated(a) =>
+      context.system.log.debug("Received Terminated for {}", a)
+    case StopAggregate(aggregateId) =>
+      context.system.log.debug("Received StopAggregate for {}", aggregateId)
+      stopAggregate(aggregateId)
+  }
+
+  private def ensureAggregateIsRunning(aggregateRootId: String): Unit = {
+    val foundAggregate = routeeMap.getOrElseUpdate(
+      aggregateRootId,
+      context.actorOf(aggregateRootCreator.props(aggregateRootId))
+    )
+    context.watch(foundAggregate)
+    timers.startTimerWithFixedDelay(aggregateRootId, StopAggregate(aggregateRootId), idleTime)
+  }
+
+  private def stopAggregate(aggregateId: String): Unit = {
+    routeeMap.get(aggregateId).foreach { actorRef =>
+      timers.cancel(aggregateId)
+      router = router.removeRoutee(actorRef)
+      context.stop(actorRef)
+    }
+    routeeMap.remove(aggregateId)
+  }
+}
+
+private final class AggregateRoutingLogic(routeeMap: collection.mutable.Map[String, ActorRef]) extends RoutingLogic {
+
+  override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee = {
+    message match {
+      case msg: DomainCommand =>
+        routeeMap.get(msg.aggregateRootId).fold[Routee](NoRoutee)(foundRef => ActorRefRoutee(foundRef))
+      case other =>
+        NoRoutee
+    }
+  }
+}
+
+object AggregateRoutingLogic {
+  trait AggregateControl
+  final case class StopAggregate(aggregateId: String) extends AggregateControl
 }

--- a/bounded-core/src/test/resources/logback-test.xml
+++ b/bounded-core/src/test/resources/logback-test.xml
@@ -1,46 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--<configuration>-->
-
-<!--    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">-->
-<!--        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
-<!--            <level>INFO</level>-->
-<!--        </filter>-->
-<!--        <encoder>-->
-<!--            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>-->
-<!--        </encoder>-->
-<!--    </appender>-->
-
-<!--    &lt;!&ndash;-->
-<!--    Logging from tests are silenced by this appender. When there is a test failure-->
-<!--    the captured logging events are flushed to the appenders defined for the-->
-<!--    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.-->
-<!--    &ndash;&gt;-->
-<!--    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />-->
-
-<!--    &lt;!&ndash;-->
-<!--    The appenders defined for this CapturingAppenderDelegate logger are used-->
-<!--    when there is a test failure and all logging events from the test are-->
-<!--    flushed to these appenders.-->
-<!--    &ndash;&gt;-->
-<!--    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >-->
-<!--        <appender-ref ref="STDOUT"/>-->
-<!--    </logger>-->
-
-<!--    <root level="DEBUG">-->
-<!--        <appender-ref ref="CapturingAppender"/>-->
-<!--    </root>-->
-<!--</configuration>-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-      <encoder>
-        <pattern>%d [%t] %highlight(%-5p) %cyan(%logger{25}) - %m%n</pattern>
-      </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+        </encoder>
     </appender>
 
-    <logger name="akka" level="DEBUG" />
-    <root level="DEBUG">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
 
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
+    </root>
 </configuration>

--- a/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/ClassicCommandGatewaySpec.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/ClassicCommandGatewaySpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016-2021 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.aggregate
+
+import akka.actor.ActorSystem
+import akka.testkit.{EventFilter, TestKit}
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+import org.scalatest.time.{Millis, Seconds, Span}
+
+class ClassicCommandGatewaySpec
+    extends TestKit(
+      ActorSystem(
+        "ClassicCommandGatewaySpec",
+        ConfigFactory.parseString(s"""
+    akka.persistence.publish-plugin-commands = on
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    akka.persistence.journal.inmem.test-serialization = on
+    akka.actor.warn-about-java-serializer-usage = off
+    # snapshot store plugin is NOT defined, things should still work
+    akka.persistence.snapshot-store.local.dir = "target/snapshots-${classOf[TypedCommandGatewaySpec].getName}/"
+    #PLEASE NOTE THAT CoordinatedShutdown needs to be disabled as below in order to run the test properly
+    #SEE https://doc.akka.io/docs/akka/current/coordinated-shutdown.html at the end of the page
+    akka.coordinated-shutdown.terminate-actor-system = off
+    akka.coordinated-shutdown.run-by-actor-system-terminate = off
+    akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
+    akka.cluster.run-coordinated-shutdown-when-down = off
+    akka.loggers = ["akka.testkit.TestEventListener"]
+    """)
+      )
+    )
+    with AsyncFlatSpecLike
+    with ScalaFutures
+    with Matchers
+    with BeforeAndAfterAll {
+
+  //Setup required supporting classes
+  implicit val timeout         = Timeout(10.seconds)
+  implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(100, Millis))
+  implicit val ec              = ExecutionContext.global
+
+  val classicSimpleCreator = new ClassicSimpleAggregateCreator(system)
+  val commandGateway       = new RouterCommandGateway(system, 2.seconds, classicSimpleCreator)
+
+  import akka.pattern.ask
+  import ClassicSimpleAggregate._
+
+  //All commands are valid in this test
+  implicit val commandValidator = new ValidateableCommand[Create] {
+    override def validate(cmd: Create): Future[Create] =
+      Future.successful(cmd)
+  }
+
+  implicit val commandValidator2 = new ValidateableCommand[AddItem] {
+    override def validate(cmd: AddItem): Future[AddItem] =
+      Future.successful(cmd)
+  }
+
+  implicit val commandValidator3 = new ValidateableCommand[GetItems] {
+    override def validate(cmd: GetItems): Future[GetItems] =
+      Future.successful(cmd)
+  }
+
+  behavior of "Classic Command Gateway"
+
+  "Classic Simple Aggregate" should "work as expected" in {
+    val aggregateId  = "testAr0"
+    val aggregateRef = system.actorOf(classicSimpleCreator.props(aggregateId))
+    whenReady(aggregateRef.ask(Create(aggregateId))) { answer => assert(answer == Ok(List(Created("testAr0")))) }
+    assert(true)
+  }
+
+  "Command Gateway" should "hanlde multiple commands to a single aggregate" in {
+    val testAggregateRootId1 = "testAr1"
+
+    whenReady(commandGateway.send(Create(testAggregateRootId1))) { answer => assert(answer == ()) }
+
+    whenReady(commandGateway.sendAndAsk(AddItem(testAggregateRootId1, "item1"))) { answer =>
+      assert(answer == Ok(List(ItemAdded("testAr1", "item1"))))
+    }
+
+    assert(true)
+  }
+
+  it should "stop and restart an aggregate root when idle time has passed" in {
+
+    val testAggregateRootId1 = "testAr1"
+
+    EventFilter.debug(start = "Received Terminated for Actor", occurrences = 1).intercept {
+      commandGateway.send(AddItem(testAggregateRootId1, "item2"))
+    }
+
+    whenReady(commandGateway.sendAndAsk(GetItems(testAggregateRootId1))) { answer =>
+      assert(answer == Ko(Items(Seq("item1", "item2"))))
+    }
+
+    assert(true)
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, 30.seconds, verifySystemShutdown = true)
+  }
+
+}

--- a/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/ClassicSimpleAggregate.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/aggregate/ClassicSimpleAggregate.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016-2021 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.aggregate
+
+import akka.actor.{ActorSystem, Props}
+import scala.collection.immutable.Seq
+import ClassicSimpleAggregate._
+
+class ClassicSimpleAggregate(aggregateRootId: String) extends AggregateRootActor[ClassicSimpleAggregateState] {
+
+  override def aggregateId: String = aggregateRootId
+
+  override def handleCommand(command: DomainCommand, aggregateState: Option[ClassicSimpleAggregateState]): Reply = {
+    command match {
+      case Stop(aggregateRootId) =>
+        context.stop(self)
+        Ok(Seq.empty)
+      case Create(aggregateRootId) =>
+        Ok(List(Created(aggregateRootId)))
+      case AddItem(aggregateRootId, newItem) =>
+        Ok(
+          Seq(
+            ItemAdded(
+              aggregateRootId,
+              newItem
+            )
+          )
+        )
+      case GetItems(aggregateRootId) =>
+        aggregateState.fold(Ko(Items(Seq.empty)))(state => Ko(Items(state.items.toSeq)))
+      case other => Ko(new UnexpectedCommand(other))
+    }
+  }
+
+  override def newState(evt: DomainEvent): Option[ClassicSimpleAggregateState] = {
+    evt match {
+      case Created(aggregateRootId) =>
+        log.debug("Create new state based on event {}", evt)
+        Some(ClassicSimpleAggregateState(List.empty))
+      case _ =>
+        log.error("Event {} is not valid to create a new TestAggregateRootState")
+        throw new IllegalArgumentException(s"Event $evt is not valid to create a new TestAggregateRootState")
+    }
+  }
+}
+
+object ClassicSimpleAggregate {
+
+  trait SimpleCommand                              extends DomainCommand
+  final case class Create(aggregateRootId: String) extends SimpleCommand
+  final case class Stop(aggregateRootId: String)   extends SimpleCommand
+  final case class StopAfter(
+    aggregateRootId: String,
+    waitInSecs: Integer
+  ) extends SimpleCommand
+  final case class AddItem(
+    aggregateRootId: String,
+    item: String
+  ) extends SimpleCommand
+  final case class GetItems(aggregateRootId: String) extends SimpleCommand
+
+  //For testing there is no CQRS pattern and this misuses the HandlingFailure response to
+  //get part of the state back for verification during a test
+  case class Items(items: Seq[String]) extends HandlingFailure
+
+  trait SimpleEvent                                    extends DomainEvent
+  final case class Created(id: String)                 extends SimpleEvent
+  final case class ItemAdded(id: String, item: String) extends SimpleEvent
+
+  case class ClassicSimpleAggregateState(items: List[String]) extends AggregateState[ClassicSimpleAggregateState] {
+    override def update(event: DomainEvent): Option[ClassicSimpleAggregateState] = {
+      event match {
+        case evt: Created =>
+          Some(this)
+        case evt: ItemAdded =>
+          Some(this.copy(items = items :+ evt.item))
+        case other => throw new IllegalArgumentException(s"Cannot update state based on event $other")
+      }
+    }
+  }
+
+  val aggregateRootTag = "ar-simpleclassic"
+}
+
+class ClassicSimpleAggregateCreator(system: ActorSystem) extends AggregateRootCreator {
+
+  override def props(aggregateRootId: String): Props = {
+    system.log.debug("Returning new Props for {}", aggregateRootId)
+    Props(
+      classOf[ClassicSimpleAggregate],
+      aggregateRootId
+    )
+  }
+
+}

--- a/bounded-core/src/test/scala/io/cafienne/bounded/eventmaterializers/SpecConfig.scala
+++ b/bounded-core/src/test/scala/io/cafienne/bounded/eventmaterializers/SpecConfig.scala
@@ -67,9 +67,7 @@ object SpecConfig {
       |      refresh-interval = "10ms"
       |      max-buffer-size = "1000"
       |    }
-      |
       |    bounded.eventmaterializers.publish = true
-      |
       |    bounded.eventmaterializers.offsetstore {
       |       type = "inmemory"
       |   }

--- a/bounded-test/src/main/scala/io/cafienne/bounded/test/TestableProjection.scala
+++ b/bounded-test/src/main/scala/io/cafienne/bounded/test/TestableProjection.scala
@@ -19,6 +19,7 @@ import io.cafienne.bounded.eventmaterializers.{
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import akka.persistence.testkit.scaladsl.PersistenceTestKit
 
 object TestableProjection {
 
@@ -49,6 +50,7 @@ class TestableProjection private (system: ActorSystem, timeout: Timeout, tags: S
   private var materializerId: Option[UUID]                   = None
 
   val eventStreamListener = TestProbe()
+//  val persistenceTestKit  = PersistenceTestKit(system)
 
   if (!system.settings.config.hasPath("bounded.eventmaterializers.publish") || !system.settings.config.getBoolean(
         "bounded.eventmaterializers.publish"
@@ -76,6 +78,9 @@ class TestableProjection private (system: ActorSystem, timeout: Timeout, tags: S
 
   // Blocking way to store events.
   private def storeEvents(evt: Seq[DomainEvent]): Unit = {
+
+//    evt.groupBy(evt => evt.id).foreach(grp => persistenceTestKit.persistForRecovery(grp._1, grp._2))
+
     val storeEventsActor =
       system.actorOf(Props(classOf[CreateEventsInStoreActor], evt.head.id, tags), "create-events-actor")
 

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableAggregateRootSpec.scala
@@ -6,7 +6,9 @@ package io.cafienne.bounded.test
 
 import java.time.OffsetDateTime
 import akka.actor.ActorSystem
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.event.{Logging, LoggingAdapter}
+import akka.persistence.testkit.PersistenceTestKitPlugin
 import akka.testkit.TestKit
 import akka.util.Timeout
 import io.cafienne.bounded.test.TestableAggregateRoot._
@@ -23,7 +25,7 @@ class TestableAggregateRootSpec extends AsyncWordSpecLike with Matchers with Sca
 
   //Setup required supporting classes
   implicit val timeout                = Timeout(10.seconds)
-  implicit val system                 = ActorSystem("TestSystem", SpecConfig.testConfig)
+  implicit val system                 = ActorSystem("TestSystem", PersistenceTestKitPlugin.config.withFallback(SpecConfig.testConfig))
   implicit val logger: LoggingAdapter = Logging(system, getClass)
 
   val testAggregateRootCreator = new TestAggregateRootCreator(system)

--- a/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableProjectionSpec.scala
+++ b/bounded-test/src/test/scala/io/cafienne/bounded/test/TestableProjectionSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016-2021 Cafienne B.V. <https://www.cafienne.io/bounded>
+ */
+
+package io.cafienne.bounded.test
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.util.Timeout
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpecLike
+import akka.Done
+import com.typesafe.scalalogging.Logger
+import io.cafienne.bounded.eventmaterializers.{AbstractReplayableEventMaterializer, OffsetStoreProvider}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import DomainProtocol._
+import akka.persistence.query.Sequence
+import io.cafienne.bounded.aggregate.DomainEvent
+
+import java.time.OffsetDateTime
+
+class TestableProjectionSpec extends AsyncWordSpecLike with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val timeout = Timeout(10.seconds)
+  implicit val system =
+    ActorSystem("TestableProjectionSpecSystem", SpecConfig.testConfig)
+
+  implicit val logger: LoggingAdapter = Logging(system, getClass)
+
+  val testProjectionMaterializer = new TestProjectionMaterializer(system) with OffsetStoreProvider
+  val metaDate                   = TestMetaData(OffsetDateTime.now(), None, None)
+
+  "The testable projection" must {
+
+    val testAggregateRootId1 = "arTest1"
+    val evt1                 = InitialStateCreated(metaDate, testAggregateRootId1, "initialState")
+    val evt2                 = StateUpdated(metaDate, testAggregateRootId1, "updatedState")
+
+    val fixture = TestableProjection.given(Seq(evt1, evt2), Set("ar-test", "aggregate"))
+
+    "Store basic events at the start" in {
+
+      whenReady(fixture.startProjection(testProjectionMaterializer)) { replayResult =>
+        logger.info("replayResult: {}", replayResult)
+        assert(replayResult.offset == Some(Sequence(2L)))
+      }
+    }
+
+    "Store more events" in {
+      val evt3 = StateUpdated(metaDate, testAggregateRootId1, "morestate")
+
+      fixture.addEvent(evt3)
+
+      testProjectionMaterializer.events.size should be(3)
+    }
+
+  }
+}
+
+class TestProjectionMaterializer(actorSystem: ActorSystem) extends AbstractReplayableEventMaterializer(actorSystem) {
+
+  /**
+    * Tagname used to identify eventstream to listen to
+    */
+  override val tagName: String = "ar-test"
+
+  /**
+    * Mapping name of this listener
+    */
+  override val matMappingName: String = "test-view"
+
+  override lazy val logger: Logger = Logger(LoggerFactory.getLogger(TestProjectionMaterializer.this.getClass))
+
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  var events: Seq[DomainEvent] = Seq.empty[DomainEvent]
+
+  override def handleReplayEvent(evt: Any): Future[Done] = handleEvent(evt)
+
+  override def handleEvent(evt: Any): Future[Done] = {
+    try {
+      evt match {
+        case event: InitialStateCreated =>
+          events = events :+ event
+          Future.successful(Done)
+        case event: StateUpdated =>
+          events = events :+ event
+          Future.successful(Done)
+        case _ => Future.successful(Done)
+      }
+    } catch {
+      case ex: Throwable =>
+        logger.error(
+          "Unable to process event: " + evt.getClass.getSimpleName + Option(ex.getCause)
+            .map(ex => ex.getMessage)
+            .getOrElse("") + s" ${ex.getMessage} " + " exception: " + logException(ex),
+          ex
+        )
+        Future.failed(ex)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val basicSettings = {
   val supportedScalaVersions = List(scala213, scala212)
 
   Seq(
-    organization := "io.cafienne.bounded",
+    organization := "io.cafienne",
     description := "Scala and Akka based Domain Driven Design Framework",
     scalaVersion := scala213,
     crossScalaVersions := supportedScalaVersions,

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.3.0"
+version in ThisBuild := "0.3.1"


### PR DESCRIPTION
When an Aggregate is used, it stays in memory.
This pull request allows for idle time passivation that leads to removal from memory. 